### PR TITLE
Appended useful information buttons in readme.md

### DIFF
--- a/.github/issue_template/bug_report.md
+++ b/.github/issue_template/bug_report.md
@@ -1,14 +1,11 @@
 ---
-name: New Issue
-about: Create a report to help us improve software.
-title: Please describe issue/bug you found.
-labels: question
-assignees: jge162
-
+Name: New Issue
+About: Create a report to help us improve our software
+Title: Please describe issue/bug you found
+Labels: question
+Assignees: jge162
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Describe the bug**: a clear and concise description of what the bug is.
 
-**Additional context**
-Add any other context about the problem here.
+**Additional context**: add any other context about the problem here.

--- a/.github/issue_template/feature_request.md
+++ b/.github/issue_template/feature_request.md
@@ -1,0 +1,15 @@
+---
+Name: Feature request
+About: Suggest an idea for this project
+Title: Please describe the feature
+Labels: question
+Assignees: jge162
+---
+
+**Is your feature request related to a problem? Please describe** a clear and concise description of what the problem is. 
+
+**Describe the solution you'd like**: a clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**: a clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**: add any other context or screenshots about the feature request here.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 ![GitHub package.json version](https://img.shields.io/github/package-json/v/jge162/Action-workflows)
 ![GitHub](https://img.shields.io/github/license/jge162/Action-workflows?color=purple)
 
+[![Contributors](https://img.shields.io/github/contributors/jge162/Action-workflows.svg)](https://github.com/jge162/Action-workflows/graphs/contributors) [![Forks](https://img.shields.io/github/forks/jge162/Action-workflows.svg)](https://github.com/jge162/Action-workflows/network/members) [![Issues](https://img.shields.io/github/issues/jge162/Action-workflows.svg)](https://github.com/jge162/Action-workflows/issues) [![Pull Request](https://img.shields.io/github/issues-pr-closed-raw/jge162/Action-workflows)](https://github.com/jge162/Action-workflows/pulls)
+
 <img src="https://user-images.githubusercontent.com/31228460/218295872-1865b4ba-9c3c-4a28-bac8-0fd11c7c37f6.png" width="79%">
 
 ## Purpose of this repository:


### PR DESCRIPTION
### Hi Jeremy and Geo 👋 ,

_In this PR I suggest including this custom buttons to the repo; the buttons show useful info in the readme.md (forks, PR'S closed, contributors, etc.)_

I think it's a nice idea but I don't know where to implement them so they look good (in the readme.md). You can either correct them later or tell me where to put it so I correct the PR. 😄 

**Preview of the buttons** (these are clickeable and take you to the insights of the repo of that specific stat: test it out!):

[![Contributors](https://img.shields.io/github/contributors/jge162/Action-workflows.svg)](https://github.com/jge162/Action-workflows/graphs/contributors) [![Forks](https://img.shields.io/github/forks/jge162/Action-workflows.svg)](https://github.com/jge162/Action-workflows/network/members) [![Issues](https://img.shields.io/github/issues/jge162/Action-workflows.svg)](https://github.com/jge162/Action-workflows/issues) [![Pull Request](https://img.shields.io/github/issues-pr-closed-raw/jge162/Action-workflows)](https://github.com/jge162/Action-workflows/pulls)


> See you guys! I hope you like this! 😸 