### PR TITLE
Appended useful information buttons in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 ![GitHub package.json version](https://img.shields.io/github/package-json/v/jge162/Action-workflows)
 ![GitHub](https://img.shields.io/github/license/jge162/Action-workflows?color=purple)
 
+[![Contributors](https://img.shields.io/github/contributors/jge162/Action-workflows.svg)](https://github.com/jge162/Action-workflows/graphs/contributors) [![Forks](https://img.shields.io/github/forks/jge162/Action-workflows.svg)](https://github.com/jge162/Action-workflows/network/members) [![Issues](https://img.shields.io/github/issues/jge162/Action-workflows.svg)](https://github.com/jge162/Action-workflows/issues) [![Pull Request](https://img.shields.io/github/issues-pr-closed-raw/jge162/Action-workflows)](https://github.com/jge162/Action-workflows/pulls)
+
 <img src="https://user-images.githubusercontent.com/31228460/218295872-1865b4ba-9c3c-4a28-bac8-0fd11c7c37f6.png" width="79%">
 
 ## Purpose of this repository:


### PR DESCRIPTION
### Hi Jeremy and Geo 👋 ,

_In this PR I suggest including this custom buttons to the repo; the buttons show useful info in the readme.md (forks, PR'S closed, contributors, etc.)_

I think it's a nice idea but I don't know where to implement them so they look good (in the readme.md). You can either correct them later or tell me where to put it so I correct the PR. 😄 

**Preview of the buttons** (these are clickeable and take you to the insights of the repo of that specific stat: test it out!):

[![Contributors](https://img.shields.io/github/contributors/jge162/Action-workflows.svg)](https://github.com/jge162/Action-workflows/graphs/contributors) [![Forks](https://img.shields.io/github/forks/jge162/Action-workflows.svg)](https://github.com/jge162/Action-workflows/network/members) [![Issues](https://img.shields.io/github/issues/jge162/Action-workflows.svg)](https://github.com/jge162/Action-workflows/issues) [![Pull Request](https://img.shields.io/github/issues-pr-closed-raw/jge162/Action-workflows)](https://github.com/jge162/Action-workflows/pulls)


> See you guys! I hope you like this! 😸 

![8038-yeah](https://user-images.githubusercontent.com/124001513/222935991-908bcbc9-933b-488b-8d22-3ab2a3e7c03e.gif)
