### PR TITLE
Fix: Updated hours to review issue

### DIFF
--- a/.github/workflows/comment_on_issue.yml
+++ b/.github/workflows/comment_on_issue.yml
@@ -31,5 +31,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Thank you for opening this issue! Our team will review it within 24-48 hours.'
+              body: 'Thank you for opening this issue! The team will review it within 1-12 hours.'
             })


### PR DESCRIPTION
### Hi Jeremy and Geo 👋 ,

**In this PR, I fixed the time the bot suggest for the team to revise an issue; from 24-48 to 1-12hs, because it was not correct.**

_This fixes a comment in #509._

> Cya! 🐱

![2295-catpetting](https://user-images.githubusercontent.com/124001513/223275917-1dfa0e11-99ad-4c41-a4ed-e31f79dc496d.gif)
 